### PR TITLE
Move assertion for intent FbReactFragment's onActivityResult

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ActivityEventListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ActivityEventListener.java
@@ -9,6 +9,7 @@ package com.facebook.react.bridge;
 
 import android.app.Activity;
 import android.content.Intent;
+import androidx.annotation.Nullable;
 
 /**
  * Listener for receiving activity events. Consider using {@link BaseActivityEventListener} if
@@ -17,7 +18,7 @@ import android.content.Intent;
 public interface ActivityEventListener {
 
   /** Called when host (activity/service) receives an {@link Activity#onActivityResult} call. */
-  void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data);
+  void onActivityResult(Activity activity, int requestCode, int resultCode, @Nullable Intent data);
 
   /** Called when a new intent is passed to the activity */
   void onNewIntent(Intent intent);

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseActivityEventListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseActivityEventListener.java
@@ -9,6 +9,7 @@ package com.facebook.react.bridge;
 
 import android.app.Activity;
 import android.content.Intent;
+import androidx.annotation.Nullable;
 
 /** An empty implementation of {@link ActivityEventListener} */
 public class BaseActivityEventListener implements ActivityEventListener {
@@ -18,7 +19,8 @@ public class BaseActivityEventListener implements ActivityEventListener {
   public void onActivityResult(int requestCode, int resultCode, Intent data) {}
 
   @Override
-  public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {}
+  public void onActivityResult(
+      Activity activity, int requestCode, int resultCode, @Nullable Intent data) {}
 
   @Override
   public void onNewIntent(Intent intent) {}

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -324,7 +324,8 @@ public class ReactContext extends ContextWrapper {
   }
 
   /** Should be called by the hosting Fragment in {@link Fragment#onActivityResult} */
-  public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+  public void onActivityResult(
+      Activity activity, int requestCode, int resultCode, @Nullable Intent data) {
     for (ActivityEventListener listener : mActivityEventListeners) {
       try {
         listener.onActivityResult(activity, requestCode, resultCode, data);


### PR DESCRIPTION
Summary:
Changelog:
[Android][Changed] - Mark intent as nullable

Reviewed By: rahulraj

Differential Revision: D35058290

fbshipit-source-id: 3025de8b01660358a010c6886893d860ed4573fb

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
